### PR TITLE
Appveyor configuration for a Visual Studio 2015 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 libwdi: A Windows Driver Installation library for USB devices
 =============================================================
 
+[![Build status](https://ci.appveyor.com/api/projects/status/j85bn7r8sds2coda?svg=true)](https://ci.appveyor.com/project/haata/libwdi)
+
+
 Main features
 -------------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,59 @@
+# appveyor file for libwdi
+
+# General Build Configuration
+version: "{build}"
+
+os: Visual Studio 2015
+
+init:
+  - git config --global core.autocrlf input
+
+# Build Setup
+build:
+  project: libwdi.sln
+  parallel: true
+
+
+# Build Matrix
+platform:
+  - Win32
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+
+# Build Dependencies
+install:
+  - curl -o libusb-win32-bin-1.2.6.0.zip -L "http://downloads.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Flibusb-win32%2F&ts=1471420545&use_mirror=pilotfiber"
+  - curl -o libusbK-3.0.7.0-bin.7z -L "http://downloads.sourceforge.net/project/libusbk/libusbK-release/3.0.7.0/libusbK-3.0.7.0-bin.7z?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Flibusbk%2Ffiles%2FlibusbK-release%2F3.0.7.0%2F&ts=1471420694&use_mirror=pilotfiber"
+  - 7z x libusb-win32-bin-1.2.6.0.zip
+  - 7z x libusbK-3.0.7.0-bin.7z
+  - dir
+
+
+# Build Steps
+build_script:
+  - msbuild "libwdi.sln" /m /p:BuildMacros="LIBUSB0_DIR=\"c:/projects/libwdi/libusb-win32-bin-1.2.6.0\";LIBUSBK_DIR=\"c:/projects/libwdi/libusbK-3.0.7.0-bin/bin\"" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+
+# Package Artifacts
+artifacts:
+  - path: '$(platform)/$(configuration)/examples/*.exe'
+  - path: $(platform)/$(configuration)/dll/libwdi.dll
+
+
+# Build Artifact Push (tagged releases only)
+deploy:
+  # GitHub Releases
+  - provider: GitHub
+    artifact: /.*\.exe/
+    draft: false
+    prerelease: false
+    # Conditions for uploading release
+    on:
+      branch: master
+      appveyor_repo_tag: true
+      configuration: Release
+      platform: Win32

--- a/libwdi/.msvc/buildsettings.props
+++ b/libwdi/.msvc/buildsettings.props
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <BuildMacros></BuildMacros>
+  </PropertyGroup>
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_WINDLL;%(PreprocessorDefinitions);$(BuildMacros)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="BuildMacros">
+      <Value>$(BuildMacros)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/libwdi/.msvc/embedder.vcxproj
+++ b/libwdi/.msvc/embedder.vcxproj
@@ -33,9 +33,11 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/libwdi/.msvc/installer_x64.vcxproj
+++ b/libwdi/.msvc/installer_x64.vcxproj
@@ -49,15 +49,19 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/libwdi/.msvc/installer_x86.vcxproj
+++ b/libwdi/.msvc/installer_x86.vcxproj
@@ -33,9 +33,11 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/libwdi/.msvc/libwdi_dll.vcxproj
+++ b/libwdi/.msvc/libwdi_dll.vcxproj
@@ -50,15 +50,19 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>

--- a/libwdi/.msvc/libwdi_static.vcxproj
+++ b/libwdi/.msvc/libwdi_static.vcxproj
@@ -50,15 +50,19 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="buildsettings.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>


### PR DESCRIPTION
- Required adding a property sheet to pass C defines from the command line
- Builds with libusb-win32 and libusbK
- Builds 4 different permutations currently (x86, x64 /w Debug, Release)
- Support for pushing tagged releases (only Release/Win32 currently) to GitHub Releases

Notes:
- Appveyor also has Cygwin available so it's likely possible to setup some Cygwin builds as well
- To fully utilize Appveyor you'll need to. The Win32 Release build seemed like the most useful overall, so I started there.
  * Create an Appveyor project for libwdi
  * Change the "Build Status" link in the README.md file (currently it points to my Appveyor project)
  * Add your own GitHub auth key (https://www.appveyor.com/docs/deployment/github/), mine won't work on your repo
- Example of the  README.md (https://github.com/haata/libwdi)
- Example of GitHub Artifacts (https://github.com/haata/libwdi/releases), it's possible to add more files, platforms and/or add them to .zip files