### PR TITLE
[Zadig] Fix minor typos in a loading message

### DIFF
--- a/libwdi/libwdi_dlg.c
+++ b/libwdi/libwdi_dlg.c
@@ -56,7 +56,7 @@ static const char* progress_message[] = {
 	"Microsoft offers no means of checking progress...",
 	"...so we can't say how long it'll take...",			// 2 mins
 	"Please continue to be patient...",
-	"There's a 5 minutes timeout enventually...",
+	"There's a 5 minute timeout eventually...",
 	"...so if there's a problem, the process will abort.",
 	"I've really seen an installation take 5 minutes...",	// 3 mins
 	"...on a Vista 64 machine with a very large disk.",


### PR DESCRIPTION
Removed extra n from "enventually", and changed "5 minutes timeout" to "5 minute timeout"