### PR TITLE
wdi-simple interface 0x00 and RSA 4096 bits

### DIFF
--- a/examples/wdi-simple.c
+++ b/examples/wdi-simple.c
@@ -223,7 +223,8 @@ int __cdecl main(int argc, char** argv)
 	if (wdi_create_list(&ldev, &ocl) == WDI_SUCCESS) {
 		r = WDI_SUCCESS;
 		for (; (ldev != NULL) && (r == WDI_SUCCESS); ldev = ldev->next) {
-			if ( (ldev->vid == dev.vid) && (ldev->pid == dev.pid) && (ldev->mi == dev.mi) ) {
+			if ( (ldev->vid == dev.vid) && (ldev->pid == dev.pid) && (ldev->mi == dev.mi) &&(ldev->is_composite == dev.is_composite) ) {
+				
 				dev.hardware_id = ldev->hardware_id;
 				dev.device_id = ldev->device_id;
 				matching_device_found = TRUE;

--- a/examples/zadic.c
+++ b/examples/zadic.c
@@ -63,6 +63,7 @@ int __cdecl main(int argc, char *argv[])
 	static struct wdi_options_prepare_driver pd_options = { 0 };
 
 	static int prompt_flag = 1;
+	static unsigned char use_iface = 0;
 	static unsigned char iface = 0;
 	static unsigned short vid = 0, pid = 0;
 	static int verbose_flag = 3;
@@ -109,6 +110,7 @@ int __cdecl main(int argc, char *argv[])
 			break;
 		case 'a':
 			iface = (unsigned char)atoi(optarg);
+			use_iface = 1;
 			printf("OPT: interface number %d\n", iface);
 			break;
 		case 'b':
@@ -146,6 +148,10 @@ int __cdecl main(int argc, char *argv[])
 		device->desc = desc;
 		device->vid = vid;
 		device->pid = pid;
+		if (use_iface) {
+			device->is_composite = 1;
+			device->mi = iface;
+		}
 		printf("Creating USB device: device: \"%s\" (%04X:%04X)\n", device->desc, device->vid, device->pid);
 		wdi_set_log_level(verbose_flag);
 		if (wdi_prepare_driver(device, path, INF_NAME, &pd_options) == WDI_SUCCESS) {

--- a/libwdi/pki.c
+++ b/libwdi/pki.c
@@ -768,8 +768,9 @@ PCCERT_CONTEXT CreateSelfSignedCert(LPCSTR szCertSubject)
 		goto out;
 	}
 
-	// Generate key pair (0x0400XXXX = RSA 1024 bit)
-	if (!CryptGenKey(hCSP, AT_SIGNATURE, 0x04000000 | CRYPT_EXPORTABLE, &hKey)) {
+	// Generate key pair using RSA 4096
+	// (Key_size <<16) because key size is in upper 16 bits
+	if (!CryptGenKey(hCSP, AT_SIGNATURE, (4096U<<16) | CRYPT_EXPORTABLE, &hKey)) {
 		wdi_dbg("could not generate keypair: %s", winpki_error_str(0));
 		goto out;
 	}


### PR DESCRIPTION
wdi-simple had a similar bug like zadic with interface 0x00 - it would select the base usb devices instead of the correct interface.

Changed RSA key size to 4096 bits and documented the magic number creation.
Since key is auto-generated and never stored this should not be a security issue - but I think MS could disable 1024 bit keys alltogether at some point because they can be factored. 

I also did not like the magic number that had no obvious reference to key size unless one is very fluent with hex calculations and bit shifts.