### PR TITLE
[misc] make custom definition of DEVPKEY_Device_BusReportedDeviceDesc static

### DIFF
--- a/libwdi/libwdi_i.h
+++ b/libwdi/libwdi_i.h
@@ -261,7 +261,7 @@ typedef struct {
 } DEVPROPKEY;
 #endif
 
-const DEVPROPKEY DEVPKEY_Device_BusReportedDeviceDesc = {
+static const DEVPROPKEY DEVPKEY_Device_BusReportedDeviceDesc = {
 	{ 0x540b947e, 0x8b40, 0x45bc, {0xa8, 0xa2, 0x6a, 0x0b, 0x89, 0x4c, 0xbd, 0xa2} }, 4 };
 
 // Check the status of the installer process


### PR DESCRIPTION
When linking against some windows libraries (SetupApi.lib probably) i get the following linker error:
`_DEVPKEY_Device_BusReportedDeviceDesc already defined`.
By making the custom definition in libwdi static the user can link against windows libraries without having duplicate symbols.