### PR TITLE
Using bash instead of sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # rebuilds the Windows def file by exporting all LIBDWI API calls
 create_def()


### PR DESCRIPTION
Some shells (like dash - ubuntu's shell) have a different semantics of builtin `type -P`. This script doesn't seem to work with dash because of that.