### PR TITLE
Add timeout to wdi-simple installers

### DIFF
--- a/examples/wdi-simple.iss
+++ b/examples/wdi-simple.iss
@@ -54,8 +54,9 @@ Name: "{group}\Uninstall YourApplication"; Filename: "{uninstallexe}"
 ; -s, --silent               silent mode
 ; -b, --progressbar=[HWND]   display a progress bar during install
 ;                            an optional HWND can be specified
+; -o, --timeout              timeout (in millis) to wait for any pending installations
 ; -l, --log                  set log level (0 = debug, 4 = none)
 ; -h, --help                 display usage
 ;
-Filename: "{app}\wdi-simple.exe"; Flags: "runhidden"; Parameters: " --name ""XBox Controller"" --vid 0x045e --pid 0x0289 --progressbar={wizardhwnd}"; StatusMsg: "Installing YourApplication driver (this may take a few seconds) ...";
+Filename: "{app}\wdi-simple.exe"; Flags: "runhidden"; Parameters: " --name ""XBox Controller"" --vid 0x045e --pid 0x0289 --progressbar={wizardhwnd} --timeout 120000"; StatusMsg: "Installing YourApplication driver (this may take a few seconds) ...";
 

--- a/examples/wdi-simple.nsi
+++ b/examples/wdi-simple.nsi
@@ -62,11 +62,12 @@ SectionEnd
 ; -s, --silent               silent mode
 ; -b, --progressbar=[HWND]   display a progress bar during install
 ;                            an optional HWND can be specified
+; -o, --timeout              timeout (in millis) to wait for any pending installations
 ; -l, --log                  set log level (0 = debug, 4 = none)
 ; -h, --help                 display usage
 Section "wdi-simple"
   DetailPrint "Running $INSTDIR\wdi-simple.exe"
-  nsExec::ExecToLog '"$INSTDIR\wdi-simple.exe" --name "XBox Controller" --vid 0x045e --pid 0x0289 --progressbar=$HWNDPARENT'
+  nsExec::ExecToLog '"$INSTDIR\wdi-simple.exe" --name "XBox Controller" --vid 0x045e --pid 0x0289 --progressbar=$HWNDPARENT --timeout 120000'
 SectionEnd
 
 ; Uninstaller


### PR DESCRIPTION
We solved the issue https://github.com/pbatard/libwdi/issues/131 with our user

It actually had nothing (much) to do with HP Driver. However, the user had somehow misconfigured PC that kept re-installing some (different!) faulty device ad-infinitum in a loop.

Which caused the wcid-simple inside the NSIS installer to always fail. Fixing it as in the PR fixed the issue. (The HP driver does not actually override the libwdi driver, because the libwdi driver was not installed in the first place.)

I have added the timeouts to the example NSIS and ISS scripts, maybe it will help someone. I know it is an extreme edge-case but it actually helped at least 2 users.

(I have no idea what timeout zadig uses, as I cannot find `pending_install_timeout` in the zadig code. Perhaps it should be added there too somewhere to fix similar issue.)