### PR TITLE
cat_file_size in libwdi

### DIFF
--- a/libwdi/libwdi.c
+++ b/libwdi/libwdi.c
@@ -1403,7 +1403,7 @@ int LIBWDI_API wdi_prepare_driver(struct wdi_device_info* device_info, const cha
 		// Tokenize the cat file (for WDF version)
 		if ((cat_file_size = tokenize_internal(cat_template[driver_type],
 			&dst, inf_entities, "#", "#", 0)) <= 0) {
-			wdi_err("Could not tokenize cat file (%d)", inf_file_size);
+			wdi_err("Could not tokenize cat file (%d)", cat_file_size);
 			r = WDI_ERROR_ACCESS;
 			goto out;
 		}


### PR DESCRIPTION
Wrong file size is used when reporting an error that the cat file cannot
be tokenized. Fixes this. Closes #230.