### PR TITLE
Add wdi_sign_driver_inf()

### DIFF
--- a/libwdi/libwdi.h
+++ b/libwdi/libwdi.h
@@ -262,6 +262,12 @@ LIBWDI_EXP int LIBWDI_API wdi_prepare_driver(struct wdi_device_info* device_info
 								  const char* inf_name, struct wdi_options_prepare_driver* options);
 
 /*
+ * Sign a specific inf file
+ */
+LIBWDI_EXP int LIBWDI_API wdi_sign_driver_inf(struct wdi_device_info* device_info, const char* path,
+								  const char* inf_input_name, struct wdi_options_prepare_driver* options);
+
+/*
  * Install a driver for a specific device
  */
 LIBWDI_EXP int LIBWDI_API wdi_install_driver(struct wdi_device_info* device_info, const char* path,


### PR DESCRIPTION
This PR add wdi_sign_driver_inf() to the libwdi API. It lets you supply an own INF file which is processed the same way like the built-in winusb.inf, libusb.inf and so on. It can also include "tokenization macros" like #CAT_FILENAME# or #WDF_VERSION#.

This allows to use a more customized INF than the automatically generated ones. For example, the INF can handle multiple devices, or the DFU mode of some devices.