### PR TITLE
fix link to public source

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
 			<h2>License</h2>
 			<p><a href="https://www.gnu.org/licenses/gpl.html">GNU General Public License (GPL) version 3</a> or later.<br />You are free to distribute, modify or even sell the software, insofar as you respect the GPLv3 license.</p>
 			<p>Zadig is based on <a href="https://github.com/pbatard/libwdi">libwdi</a> which uses an <a href="https://www.gnu.org/licenses/lgpl.html">LGPL version 3</a> or later license</a>.
-			<p>The executable is produced in a 100% transparent manner, from its <a href=https://github.com/pbatard/libwdi/tree/master/examples">public source</a>, using a <a href="https://visualstudio.microsoft.com/">Visual Studio</a> environment.</p>
+			<p>The executable is produced in a 100% transparent manner, from its <a href="https://github.com/pbatard/libwdi/tree/master/examples">public source</a>, using a <a href="https://visualstudio.microsoft.com/">Visual Studio</a> environment.</p>
 			<a name="versions"></a>
 			<h2>Changelog</h2>
 			<ul>


### PR DESCRIPTION
The opening quote was missing, causing the link to break.