### PR TITLE
Libusb win32 update

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   WDK_URL: https://go.microsoft.com/fwlink/p/?LinkID=253170
-  LIBUSB0_URL: https://sourceforge.net/projects/libusb-win32/files/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip/download
+  LIBUSB0_URL: https://sourceforge.net/projects/libusb-win32/files/libusb-win32-releases/1.2.7.3/libusb-win32-bin-1.2.7.3.zip/download
   LIBUSBK_URL: https://github.com/mcuee/libusbk/releases/download/V3.1.0.0/libusbK-3.1.0.0-bin.7z
   BUILD_OPTIONS: '--enable-toggable-debug --enable-examples-build --disable-debug --disable-shared'
   DRIVERS_PATHS: '--with-wdkdir="wdk/Windows Kits/8.0" --with-wdfver=1011 --with-libusb0="libusb0" --with-libusbk="libusbk/bin"'

--- a/.github/workflows/vs2022.yml
+++ b/.github/workflows/vs2022.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   WDK_URL: https://go.microsoft.com/fwlink/p/?LinkID=253170
-  LIBUSB0_URL: https://sourceforge.net/projects/libusb-win32/files/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip/download
+  LIBUSB0_URL: https://sourceforge.net/projects/libusb-win32/files/libusb-win32-releases/1.2.7.3/libusb-win32-bin-1.2.7.3.zip/download
   LIBUSBK_URL: https://github.com/mcuee/libusbk/releases/download/V3.1.0.0/libusbK-3.1.0.0-bin.7z
   SOLUTION_FILE_PATH: ./libwdi.sln
   BUILD_MACROS: '"WDK_DIR=\"../wdk/Windows Kits/8.0\";LIBUSB0_DIR=\"../libusb0\";LIBUSBK_DIR=\"../libusbk/bin\""'


### PR DESCRIPTION
We have promoted libusb-1.2.7.3 to be a formal release (initially a snapshot release). It will be good to integrate the release in Zadig.