### PR TITLE
[fix] crash if SignerSignEx failed

### DIFF
--- a/libwdi/pki.c
+++ b/libwdi/pki.c
@@ -1035,7 +1035,7 @@ BOOL SelfSignFile(LPCSTR szFileName, LPCSTR szCertSubject)
 	// Sign file with cert
 	hResult = pfSignerSignEx(0, &signerSubjectInfo, &signerCert, &signerSignatureInfo, NULL, NULL, NULL, NULL, &pSignerContext);
 	if (hResult != S_OK) {
-		wdi_warn("SignerSignEx failed: %s", hResult, winpki_error_str(hResult));
+		wdi_warn("SignerSignEx failed: %s", winpki_error_str(hResult));
 		goto out;
 	}
 	r = TRUE;


### PR DESCRIPTION
zadig crashed due to bad incorrect __VA_ARGS__